### PR TITLE
Support custom "epp" tag attributes

### DIFF
--- a/epp.gemspec
+++ b/epp.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("uuidtools", [">= 0"])
 
   s.add_development_dependency("shoulda", [">= 0"])
+  s.add_development_dependency("minitest", [">= 0"])
   s.add_development_dependency("mocha", [">= 0"])
   s.add_development_dependency("rake", [">= 0"])
 end

--- a/test/test_epp.rb
+++ b/test/test_epp.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class EppTest < Test::Unit::TestCase
+class EppTest < Minitest::Test
   context "EPP" do
     context "server" do
       setup do
@@ -31,9 +31,8 @@ class EppTest < Test::Unit::TestCase
           epp = Epp::Server.new(:server => "a", :tag => "a")
         end
 
-        assert_nothing_raised do
-          epp = Epp::Server.new(:server => "a", :tag => "a", :password => "a")
-        end
+        # Assert nothing raised
+        assert Epp::Server.new(:server => "a", :tag => "a", :password => "a")
       end
 
       should "set instance variables for attributes" do
@@ -195,9 +194,8 @@ class EppTest < Test::Unit::TestCase
           e = EppErrorResponse.new(:xml => "a", :code => "a")
         end
 
-        assert_nothing_raised do
-          e = EppErrorResponse.new(:xml => "a", :code => "a", :message => "a")
-        end
+        # Assert nothing raised
+        assert EppErrorResponse.new(:xml => "a", :code => "a", :message => "a")
       end
 
       should "print error message to string" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,13 @@
 require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
+# require 'test/unit'
 require 'shoulda'
-require 'mocha'
+require 'mocha/setup'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'epp'
 
-class Test::Unit::TestCase
+class Minitest::Test
 end

--- a/test/xml/new_request.xml
+++ b/test/xml/new_request.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<epp xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:ietf:params:xml:ns:epp-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd"/>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd"/>


### PR DESCRIPTION
* Support custom "epp" tag attributes on server initialization ("xmlns", "xmlns_xsi" and "xsi_schema_location"). E.g. needed for EIS api (.ee domains - https://github.com/internetee/registry/blob/master/doc/epp-examples.md) (#4)
* Fixed typo in response parsing (#3)
* Fixed issue where `services` attribute was ignored

Closes #3
Closes #4